### PR TITLE
biter-battles: adding option to only send msg to a specific team as a spectator

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -250,8 +250,14 @@ function Public.share_chat(event)
 		local a, b = string_find(event.message, "gps=", 1, false)
 		if a then return end	
 		
-		game.forces.north.print(player.name .. tag .. " (spectator): ".. event.message, color)
-		game.forces.south.print(player.name .. tag .. " (spectator): ".. event.message, color)
+		if (event.message:find("^-n ")) then
+			game.forces.north.print(player.name .. tag .. " (spectator): ".. event.message, color)
+		elseif (event.message:find("^-s ")) then 
+			game.forces.south.print(player.name .. tag .. " (spectator): ".. event.message, color)
+		else 
+			game.forces.north.print(player.name .. tag .. " (spectator): ".. event.message, color)
+			game.forces.south.print(player.name .. tag .. " (spectator): ".. event.message, color)
+		end
 	end
 end
 


### PR DESCRIPTION
Typing in chat as a spectator:
-n <msg>  to send to north
-s <msg>  to send to south