### PR TITLE
Compress difficulty values upwards

### DIFF
--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -4,13 +4,13 @@ local Server = require 'utils.server'
 
 local difficulties = {
 	
-	[1] = {name = "Beginner Mode", str = "45%", value = 0.45, color = {r=0.00, g=0.45, b=0.00}, print_color = {r=0.00, g=0.9, b=0.00}},
-	[2] = {name = "Piece of Cake", str = "60%", value = 0.6, color = {r=0.00, g=0.35, b=0.00}, print_color = {r=0.00, g=0.7, b=0.00}},
-	[3] = {name = "Easy", str = "75%", value = 0.75, color = {r=0.00, g=0.25, b=0.00}, print_color = {r=0.00, g=0.5, b=0.00}},
-	[4] = {name = "Normal", str = "100%", value = 1, color = {r=0.00, g=0.00, b=0.25}, print_color = {r=0.0, g=0.0, b=0.7}},
-	[5] = {name = "Hard", str = "150%", value = 1.5, color = {r=0.25, g=0.00, b=0.00}, print_color = {r=0.5, g=0.0, b=0.00}},
-	[6] = {name = "Nightmare", str = "200%", value = 2, color = {r=0.35, g=0.00, b=0.00}, print_color = {r=0.7, g=0.0, b=0.00}},
-	[7] = {name = "Impossible", str = "250%", value = 2.5, color = {r=0.45, g=0.00, b=0.00}, print_color = {r=0.9, g=0.0, b=0.00}}
+	[1] = {name = "Beginner Mode (1)", str = "100%", value = 1, color = {r=0.00, g=0.45, b=0.00}, print_color = {r=0.00, g=0.9, b=0.00}},
+	[2] = {name = "Piece of Cake (2)", str = "125%", value = 1.25, color = {r=0.00, g=0.35, b=0.00}, print_color = {r=0.00, g=0.7, b=0.00}},
+	[3] = {name = "Easy (3)", str = "150%", value = 1.5, color = {r=0.00, g=0.25, b=0.00}, print_color = {r=0.00, g=0.5, b=0.00}},
+	[4] = {name = "Normal (4)", str = "175%", value = 1.75, color = {r=0.00, g=0.00, b=0.25}, print_color = {r=0.0, g=0.0, b=0.7}},
+	[5] = {name = "Hard (5)", str = "200%", value = 2, color = {r=0.25, g=0.00, b=0.00}, print_color = {r=0.5, g=0.0, b=0.00}},
+	[6] = {name = "Nightmare (6)", str = "225%", value = 2.25, color = {r=0.35, g=0.00, b=0.00}, print_color = {r=0.7, g=0.0, b=0.00}},
+	[7] = {name = "Impossible (7)", str = "250%", value = 2.5, color = {r=0.45, g=0.00, b=0.00}, print_color = {r=0.9, g=0.0, b=0.00}}
 }
 
 local timeout = 18000


### PR DESCRIPTION
Compressing the difficulty range upwards to reduce the massive round times at lower difficulties. Also adding value of each difficulty to the name field as difficulty levels 1, 2, 6 and 7 don't intuitively indicate the difficulty level outside of the voting menu.