### PR TITLE
Gate science sends behind build score

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,3 +19,4 @@ jobs:
           lua tests/test-functions.lua
           lua tests/test-biter_raffle.lua
           lua tests/test-utils.lua
+          lua tests/test-science-restriction.lua

--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -264,6 +264,22 @@ local functions = {
 
         AiTargets.refresh_target_types()
     end,
+    ['bb_science_send_restriction_toggle'] = function(event)
+        local player = game.get_player(event.player_index)
+        if not player or not player.valid then
+            return
+        end
+
+        if event.element.switch_state == 'left' then
+            storage.bb_settings.science_send_score_restriction = true
+            get_actor(event, '{Science Restriction}', 'has enabled science send restriction.')
+            log(player.name .. ' has enabled science send restriction.')
+        else
+            storage.bb_settings.science_send_score_restriction = false
+            get_actor(event, '{Science Restriction}', 'has disabled science send restriction.')
+            log(player.name .. ' has disabled science send restriction.')
+        end
+    end,
 }
 
 local poll_function = {
@@ -687,6 +703,23 @@ local build_config_gui = function(player, frame)
             label.style.horizontal_align = 'left'
             label.style.vertical_align = 'bottom'
             label.style.font_color = Color.green
+
+            scroll_pane.add({ type = 'line' })
+
+            local switch_state = 'right'
+            if storage.bb_settings.science_send_score_restriction then
+                switch_state = 'left'
+            end
+            local switch = add_switch(
+                scroll_pane,
+                switch_state,
+                'bb_science_send_restriction_toggle',
+                'Science Send Restriction',
+                'Require minimum build score to send science. Higher difficulty = lower requirement.'
+            )
+            if not admin then
+                switch.ignored_by_interaction = true
+            end
 
             scroll_pane.add({ type = 'line' })
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -28,6 +28,10 @@ calc_send=[font=default-bold]Calculate sending[/font] - Calculate the impact of 
 burner_balance=You have received __1__ x [item=burner-mining-drill], check your inventory-
 silo_insert=You have received [item=rocket-silo], check your inventory
 dummy_print=[color=gray][to player __1__]:[/color] 
+science_send_restriction=Build more to unlock science sending.
+science_send_restriction_tooltip=Science buttons are grayed out because you need to build more to unlock science sending.
+send_all_tooltip=LMB - low to high, RMB - high to low
+info_button_tooltip=If you don't see a food, it may have been disabled by special game mode, or you have not been authorized by your captain.
 
 [captain]
 change_captain_wrong_member=You cant elect a player as a captain if he is not in the team of the captain ! What are you even doing !

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -1,5 +1,6 @@
 local bb_config = require('maps.biter_battles_v2.config')
 local FeedingCalculations = require('maps.biter_battles_v2.feeding_calculations')
+local FeedingRestriction = require('maps.biter_battles_v2.feeding_restriction')
 local Functions = require('maps.biter_battles_v2.functions')
 local Server = require('utils.server')
 
@@ -290,6 +291,12 @@ function Public.feed_biters_from_inventory(player, food)
         return
     end
 
+    -- Build score restriction
+    if not FeedingRestriction.can_player_send_science(player) then
+        player.print({ 'info.science_send_restriction' })
+        return
+    end
+
     local enemy_force_name = get_enemy_team_of(player.force.name) ---------------
     --enemy_force_name = player.force.name
 
@@ -342,6 +349,13 @@ function Public.feed_biters_mixed_from_inventory(player, button)
         player.print('Please wait for voting to finish before feeding')
         return
     end
+
+    -- Build score restriction
+    if not FeedingRestriction.can_player_send_science(player) then
+        player.print({ 'info.science_send_restriction' })
+        return
+    end
+
     local enemy_force_name = get_enemy_team_of(player.force.name)
     local biter_force_name = enemy_force_name .. '_biters'
     local food = {

--- a/maps/biter_battles_v2/feeding_restriction.lua
+++ b/maps/biter_battles_v2/feeding_restriction.lua
@@ -1,0 +1,51 @@
+local _TEST = storage['_TEST'] or false
+local Score
+if not _TEST then
+    Score = require('comfy_panel.score')
+end
+
+local Tables = require('maps.biter_battles_v2.tables')
+
+local Public = {}
+
+--- Pure formula: calculate required build score from difficulty value.
+--- Formula: 48 / difficulty_value (gives 240 at ITYTD, scales down with higher difficulty)
+---@param difficulty_value number
+---@return integer
+function Public.calc_required_score(difficulty_value)
+    return math.ceil(48 / difficulty_value)
+end
+
+--- Calculate required build score based on current difficulty.
+---@return integer
+function Public.get_required_build_score()
+    if not storage.bb_settings or not storage.bb_settings.science_send_score_restriction then
+        return 0
+    end
+    local difficulty = storage.difficulty_vote_value or Tables.difficulties[4].value -- default to Easy
+    return Public.calc_required_score(difficulty)
+end
+
+--- Check if player can send science based on build score restriction.
+---@param player LuaPlayer
+---@return boolean
+function Public.can_player_send_science(player)
+    if not storage.bb_settings or not storage.bb_settings.science_send_score_restriction then
+        return true
+    end
+    local score_table = Score.get_table().score_table
+    local force_name = player.force.name
+    local player_name = player.name
+
+    local tbl = score_table[force_name]
+    local score = (tbl and tbl.players and tbl.players[player_name]) or nil
+    if not score then
+        return false
+    end
+
+    local built = score.built_entities or 0
+    local required = Public.get_required_build_score()
+    return built >= required
+end
+
+return Public

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -164,6 +164,7 @@ function Public.initial_setup()
         --TEAM SETTINGS--
         ['team_balancing'] = true, --Should players only be able to join a team that has less or equal members than the opposing team?
         ['only_admins_vote'] = false, --Are only admins able to vote on the global difficulty?
+        ['science_send_score_restriction'] = true, --Require minimum build score to send science (scales with difficulty)
         --MAP SETTINGS--
         ['new_year_island'] = false,
         ['bb_map_reveal_toggle'] = true,

--- a/maps/biter_battles_v2/shortcuts.lua
+++ b/maps/biter_battles_v2/shortcuts.lua
@@ -1,6 +1,7 @@
 local Captain_event = require('comfy_panel.special_games.captain')
 local Event = require('utils.event')
 local Feeding = require('maps.biter_battles_v2.feeding')
+local FeedingRestriction = require('maps.biter_battles_v2.feeding_restriction')
 local Functions = require('maps.biter_battles_v2.functions')
 local Gui = require('utils.gui')
 local ResearchInfo = require('maps.biter_battles_v2.research_info')
@@ -86,6 +87,8 @@ local main_frame_actions = {
             player.print('Disabled by special game', { color = Color.red })
         elseif Captain_event.captain_is_player_prohibited_to_throw(player) then
             player.print('You are not allowed to send science, ask your captain', { color = Color.red })
+        elseif not FeedingRestriction.can_player_send_science(player) then
+            player.print({ 'info.science_send_restriction' }, { color = Color.red })
         else
             Feeding.feed_biters_mixed_from_inventory(player, event.button)
         end

--- a/tests/test-science-restriction.lua
+++ b/tests/test-science-restriction.lua
@@ -1,0 +1,66 @@
+---@diagnostic disable
+local lunatest = require('lunatest')
+
+-- Mock the storage to prevent Factorio API calls
+storage = { ['_TEST'] = true }
+
+local FeedingRestriction = require('maps.biter_battles_v2.feeding_restriction')
+local Tables = require('maps.biter_battles_v2.tables')
+
+-- Test each difficulty level using the actual module function
+function test_build_score_itytd()
+    local diff = Tables.difficulties[1] -- ITYTD
+    lunatest.assert_equal(240, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_hand()
+    local diff = Tables.difficulties[2] -- HaND
+    lunatest.assert_equal(138, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_poc()
+    local diff = Tables.difficulties[3] -- PoC
+    lunatest.assert_equal(96, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_easy()
+    local diff = Tables.difficulties[4] -- Easy
+    lunatest.assert_equal(64, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_normal()
+    local diff = Tables.difficulties[5] -- Normal
+    lunatest.assert_equal(48, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_hard()
+    local diff = Tables.difficulties[6] -- Hard
+    lunatest.assert_equal(24, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_fnf()
+    local diff = Tables.difficulties[7] -- FnF
+    lunatest.assert_equal(10, FeedingRestriction.calc_required_score(diff.value))
+end
+
+function test_build_score_inverse_relationship()
+    -- Verify higher difficulty = lower requirement (iterate through all difficulties)
+    local prev_score = FeedingRestriction.calc_required_score(Tables.difficulties[1].value)
+    for i = 2, #Tables.difficulties do
+        local diff = Tables.difficulties[i]
+        local score = FeedingRestriction.calc_required_score(diff.value)
+        lunatest.assert_true(score < prev_score, diff.name .. ': Expected ' .. score .. ' < ' .. prev_score)
+        prev_score = score
+    end
+end
+
+function test_build_score_all_positive_and_bounded()
+    -- All difficulties should produce positive requirements <= 240
+    for _, diff in ipairs(Tables.difficulties) do
+        local required = FeedingRestriction.calc_required_score(diff.value)
+        lunatest.assert_true(required > 0, diff.name .. ' should have positive requirement')
+        lunatest.assert_true(required <= 240, diff.name .. ' should not exceed 240')
+    end
+end
+
+lunatest.run()


### PR DESCRIPTION
### Brief description of the changes:
Adds a restriction that prevents players with insufficient build score from sending science to the opposing team. The requirement scales inversely with difficulty (higher difficulty = lower requirement). This is the implementation of Discord poll.

### Changes

- **UI**: Science buttons are grayed out (not hidden) with informative tooltip for restricted players
- **Fish exempt**: Players can always send fish regardless of build score
- **Admin toggle**: New "Science Send Restriction" option in Comfy Panel
- **Persistence**: Setting persists through map resets, enabled by default
<img width="989" height="378" alt="gate" src="https://github.com/user-attachments/assets/e65d99fe-2bf0-4ce4-943d-4ef163b8a826" />

### Formula

`required_build_score = ceil(48 / difficulty_value)`

| Difficulty | Required Build Score |
|------------|---------------------|
| ITYTD (0.2) | 240 |
| HaND (0.35) | 138 |
| PoC (0.5) | 96 |
| Easy (0.75) | 64 |
| Normal (1.0) | 48 |
| Hard (2.0) | 24 |
| FnF (5.0) | 10 |

### Tested Changes:
- [X] I've tested the changes locally
