### PR TITLE
Add research permissions to captain games

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -681,6 +681,9 @@ local function on_permission_group_added(event)
     if not this.enabled then
         return
     end
+    if not event.player_index then
+        return
+    end
     local player = game.get_player(event.player_index)
     if not player or not player.valid then
         return
@@ -695,6 +698,9 @@ end
 
 local function on_permission_group_deleted(event)
     if not this.enabled then
+        return
+    end
+    if not event.player_index then
         return
     end
     local player = game.get_player(event.player_index)

--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -151,17 +151,15 @@ local functions = {
         end
     end,
     ['comfy_panel_blueprint_toggle'] = function(event)
-        if event.element.switch_state == 'left' then
-            game.permissions
-                .get_group('Default')
-                .set_allows_action(defines.input_action.open_blueprint_library_gui, true)
-            game.permissions.get_group('Default').set_allows_action(defines.input_action.import_blueprint_string, true)
+        local enabled = event.element.switch_state == 'left'
+        local p = game.permissions.get_group('Default')
+        p.set_allows_action(defines.input_action.open_blueprint_library_gui, enabled)
+        p.set_allows_action(defines.input_action.import_blueprint_string, enabled)
+        local Captain = require('comfy_panel.special_games.captain')
+        Captain.resync_no_research_group()
+        if enabled then
             get_actor(event, '{Blueprints}', 'has enabled blueprints!')
         else
-            game.permissions
-                .get_group('Default')
-                .set_allows_action(defines.input_action.open_blueprint_library_gui, false)
-            game.permissions.get_group('Default').set_allows_action(defines.input_action.import_blueprint_string, false)
             get_actor(event, '{Blueprints}', 'has disabled blueprints!')
         end
     end,

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -2877,6 +2877,10 @@ function Public.draw_captain_manager_gui(player, main_frame)
         type = 'label',
         caption = '[font=heading-1][color=purple]Management for research[/color][/font]',
     })
+    main_frame.add({
+        type = 'label',
+        caption = 'Lock research for your team. Trusted players can still change research. Captains and vice captains can manage this.',
+    })
     main_frame.add({ type = 'button', name = 'captain_toggle_research_lock' })
     local rt = main_frame.add({ type = 'table', name = 'captain_manager_research_trustlist_table', column_count = 2 })
     rt.add({

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -173,16 +173,6 @@ local function cleanup_research_permissions()
     group.destroy()
 end
 
--- Re-sync after unfreeze restores Default permissions. The no_research group
--- may have been created during freeze phase with restricted permissions.
-local function resync_no_research_group()
-    local group = game.permissions.get_group(RESEARCH_RESTRICTED_GROUP)
-    if not group then
-        return
-    end
-    sync_research_group_permissions(group)
-end
-
 local function captain_to_team(special, name)
     if special.captainList[1] == name or special.viceCaptains.north[name] then
         return 'north'
@@ -1060,7 +1050,6 @@ local function start_captain_event()
     if storage.freeze_players == true then
         storage.freeze_players = false
         TeamManager.unfreeze_players()
-        resync_no_research_group()
         game.print('>>> Players have been unfrozen!', { color = { r = 255, g = 77, b = 77 } })
         game.print("Teams' chat have been revealed to spectators!", { color = Color.cyan })
         log('Players have been unfrozen! Game starts now!')
@@ -1959,59 +1948,48 @@ local function on_gui_click(event)
         end
     elseif name == 'captain_add_someone_to_throw_trustlist' then
         local frame = Public.get_active_tournament_frame(player, 'captain_manager_gui')
-        local playerNameUpdateText =
-            get_dropdown_value(frame.captain_manager_trustlist_table.captain_add_trustlist_playerlist)
-        if playerNameUpdateText and playerNameUpdateText ~= '' and playerNameUpdateText ~= 'Select Player' then
-            local tableToUpdate = special.northThrowPlayersListAllowed
-            local forceForPrint = 'north'
+        local selected = get_dropdown_value(frame.captain_manager_trustlist_table.captain_add_trustlist_playerlist)
+        if selected and selected ~= '' and selected ~= 'Select Player' then
+            local trustlist = special.northThrowPlayersListAllowed
+            local team = 'north'
             if player.name == special.captainList[2] then
-                tableToUpdate = special.southThrowPlayersListAllowed
-                forceForPrint = 'south'
+                trustlist = special.southThrowPlayersListAllowed
+                team = 'south'
             elseif player.name ~= special.captainList[1] then
                 player.print('You are not a captain', { color = Color.red })
                 return
             end
-            local playerToAdd = cpt_get_player(playerNameUpdateText)
-            if playerToAdd ~= nil and playerToAdd.valid then
-                if not table_contains(tableToUpdate, playerNameUpdateText) then
-                    insert(tableToUpdate, playerNameUpdateText)
-                    game.forces[forceForPrint].print(
-                        playerNameUpdateText .. ' added to throw trustlist !',
-                        { color = Color.green }
-                    )
+            local target = cpt_get_player(selected)
+            if target ~= nil and target.valid then
+                if not table_contains(trustlist, selected) then
+                    insert(trustlist, selected)
+                    game.forces[team].print(selected .. ' added to throw trustlist !', { color = Color.green })
                 else
-                    player.print(
-                        playerNameUpdateText .. ' was already added to throw trustlist !',
-                        { color = Color.red }
-                    )
+                    player.print(selected .. ' was already added to throw trustlist !', { color = Color.red })
                 end
                 Public.update_all_captain_player_guis()
             else
-                player.print(playerNameUpdateText .. ' does not even exist or not even valid !', { color = Color.red })
+                player.print(selected .. ' does not even exist or not even valid !', { color = Color.red })
             end
         end
     elseif name == 'captain_remove_someone_to_throw_trustlist' then
         local frame = Public.get_active_tournament_frame(player, 'captain_manager_gui')
-        local playerNameUpdateText =
-            get_dropdown_value(frame.captain_manager_trustlist_table.captain_remove_trustlist_playerlist)
-        if playerNameUpdateText and playerNameUpdateText ~= '' and playerNameUpdateText ~= 'Select Player' then
-            local tableToUpdate = special.northThrowPlayersListAllowed
-            local forceForPrint = 'north'
+        local selected = get_dropdown_value(frame.captain_manager_trustlist_table.captain_remove_trustlist_playerlist)
+        if selected and selected ~= '' and selected ~= 'Select Player' then
+            local trustlist = special.northThrowPlayersListAllowed
+            local team = 'north'
             if player.name == special.captainList[2] then
-                tableToUpdate = special.southThrowPlayersListAllowed
-                forceForPrint = 'south'
+                trustlist = special.southThrowPlayersListAllowed
+                team = 'south'
             elseif player.name ~= special.captainList[1] then
                 player.print('You are not a captain', { color = Color.red })
                 return
             end
-            if table_contains(tableToUpdate, playerNameUpdateText) then
-                table_remove_element(tableToUpdate, playerNameUpdateText)
-                game.forces[forceForPrint].print(
-                    playerNameUpdateText .. ' was removed in throw trustlist !',
-                    { color = Color.green }
-                )
+            if table_contains(trustlist, selected) then
+                table_remove_element(trustlist, selected)
+                game.forces[team].print(selected .. ' was removed in throw trustlist !', { color = Color.green })
             else
-                player.print(playerNameUpdateText .. ' was not found in throw trustlist !', { color = Color.red })
+                player.print(selected .. ' was not found in throw trustlist !', { color = Color.red })
             end
             Public.update_all_captain_player_guis()
         end
@@ -2095,20 +2073,20 @@ local function on_gui_click(event)
     elseif name == 'captain_add_vice_captain' then
         if is_player_a_captain(player.name) then
             local frame = Public.get_active_tournament_frame(player, 'captain_manager_gui')
-            local playerNameUpdateText =
+            local selected =
                 get_dropdown_value(frame.captain_manager_vice_captain_table.captain_add_vice_captain_playerlist)
-            if playerNameUpdateText and playerNameUpdateText ~= '' and playerNameUpdateText ~= 'Select Player' then
-                special.viceCaptains[player.force.name][playerNameUpdateText] = true
+            if selected and selected ~= '' and selected ~= 'Select Player' then
+                special.viceCaptains[player.force.name][selected] = true
                 Public.update_all_captain_player_guis()
             end
         end
     elseif name == 'captain_remove_vice_captain' then
         if is_player_a_captain(player.name) then
             local frame = Public.get_active_tournament_frame(player, 'captain_manager_gui')
-            local playerNameUpdateText =
+            local selected =
                 get_dropdown_value(frame.captain_manager_vice_captain_table.captain_remove_vice_captain_playerlist)
-            if playerNameUpdateText and playerNameUpdateText ~= '' and playerNameUpdateText ~= 'Select Player' then
-                special.viceCaptains[player.force.name][playerNameUpdateText] = nil
+            if selected and selected ~= '' and selected ~= 'Select Player' then
+                special.viceCaptains[player.force.name][selected] = nil
                 Public.update_all_captain_player_guis()
             end
         end
@@ -2877,10 +2855,7 @@ function Public.draw_captain_manager_gui(player, main_frame)
         type = 'label',
         caption = '[font=heading-1][color=purple]Management for research[/color][/font]',
     })
-    main_frame.add({
-        type = 'label',
-        caption = 'Lock research for your team. Trusted players can still change research. Captains and vice captains can manage this.',
-    })
+    main_frame.add({ type = 'label', caption = 'Vice captains can also manage this.' })
     main_frame.add({ type = 'button', name = 'captain_toggle_research_lock' })
     local rt = main_frame.add({ type = 'table', name = 'captain_manager_research_trustlist_table', column_count = 2 })
     rt.add({
@@ -3796,9 +3771,16 @@ function Public.generate_automatic_captain()
 end
 
 function Public.reset_special_games()
-    if storage.active_special_games.captain_mode then
-        cleanup_research_permissions()
+    cleanup_research_permissions()
+    if storage.special_games_variables.captain_mode then
         storage.tournament_mode = false
+    end
+end
+
+function Public.resync_no_research_group()
+    local group = game.permissions.get_group(RESEARCH_RESTRICTED_GROUP)
+    if group then
+        sync_research_group_permissions(group)
     end
 end
 

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -1175,6 +1175,7 @@ function join_team(player, force_name, forced_join, auto_join)
     Public.burners_balance(player)
     MultiSilo.on_player_changed_force(player)
     CraftingQueueList.on_team_changed(player)
+    Captain_event.on_player_joined_team(player)
     Public.clear_copy_history(player)
     Public.refresh()
 

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -1121,6 +1121,7 @@ function join_team(player, force_name, forced_join, auto_join)
         player.character.destructible = true
         Public.refresh()
         game.permissions.get_group('Default').add_player(player)
+        Captain_event.on_player_joined_team(player)
         local msg = table.concat({ 'Team ', player.force.name, ' player ', player.name, ' is no longer spectating.' })
         game.print(msg, { color = { r = 0.98, g = 0.66, b = 0.22 } })
         Sounds.notify_allies(player.force, 'utility/build_blueprint_large')

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -50,6 +50,7 @@ function Public.freeze_players()
     for _, d in pairs(defs) do
         p.set_allows_action(d, true)
     end
+    require('comfy_panel.special_games.captain').resync_no_research_group()
 end
 
 function Public.unfreeze_players()
@@ -59,6 +60,7 @@ function Public.unfreeze_players()
             p.set_allows_action(defines.input_action[action_name], true)
         end
     end
+    require('comfy_panel.special_games.captain').resync_no_research_group()
 end
 
 local function leave_corpse(player)

--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -201,7 +201,7 @@ local teleport_player_to_gulag = function(player, action)
     elseif action == 'free' then
         local surface = game.surfaces[p_data.fallback_surface_index]
         local p = p_data.position
-        local p_group = game.permissions.get_group(p_data.p_group_id)
+        local p_group = game.permissions.get_group(p_data.p_group_id) or game.permissions.get_group('Default')
         p_group.add_player(player)
         local get_tile = surface.get_tile(p)
         if get_tile.valid and get_tile.name == 'out-of-map' then

--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -201,7 +201,7 @@ local teleport_player_to_gulag = function(player, action)
     elseif action == 'free' then
         local surface = game.surfaces[p_data.fallback_surface_index]
         local p = p_data.position
-        local p_group = game.permissions.get_group(p_data.p_group_id) or game.permissions.get_group('Default')
+        local p_group = game.permissions.get_group('Default')
         p_group.add_player(player)
         local get_tile = surface.get_tile(p)
         if get_tile.valid and get_tile.name == 'out-of-map' then

--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -201,7 +201,10 @@ local teleport_player_to_gulag = function(player, action)
     elseif action == 'free' then
         local surface = game.surfaces[p_data.fallback_surface_index]
         local p = p_data.position
-        local p_group = game.permissions.get_group('Default')
+        local p_group = p_data.p_group_id and game.permissions.get_group(p_data.p_group_id)
+        if not p_group or p_group.name == 'no_research' then
+            p_group = game.permissions.get_group('Default')
+        end
         p_group.add_player(player)
         local get_tile = surface.get_tile(p)
         if get_tile.valid and get_tile.name == 'out-of-map' then


### PR DESCRIPTION
### Summary
- Captains can lock research for their team, preventing players from starting, cancelling, or reordering research in the tech tree
- Captains can whitelist trusted players who retain research access while the lock is active
- Uses a `no_research` permission group (clone of Default minus `start_research`, `cancel_research`, `move_research` actions)
- Cleans up permission groups on captain event end or captain removal

### Details
- New UI section in captain manager GUI with lock toggle, trustlist add/remove dropdowns, and status labels
- Follows the same UX pattern as the existing science throwing permissions
- Handles edge cases: player joining a locked team, spectate/rejoin, freeze/unfreeze during picking phase, captain mode cancellation

### Test plan
- [x] Start captain game, pick teams, start playing
- [x] Captain clicks "Lock research" — team players can no longer interact with tech tree
- [x] Captain adds a player to research trustlist — that player can use tech tree again
- [x] Captain removes from trustlist — player blocked again
- [x] Captain clicks "Unlock research" — everyone can use tech tree, trustlist cleared
- [x] Cancel captain event — all players back in Default group, `no_research` group deleted
- [x] Player goes spectate and rejoins locked team — still restricted
- [x] New player picked into locked team — starts restricted


### Tested Changes:
- [x] I've tested the changes with people.
