### PR TITLE
Improve performance of game_over.freeze_all_biters for game end

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -399,21 +399,29 @@ local function set_victory_time()
         table.concat({ 'Time - ', hours > 0 and (hours .. ' hours and ') or '', minutes, ' minutes' })
 end
 
-local function freeze_all_biters(surface)
-    local filter = {
-        force = {
-            'north_biters',
-            'south_biters',
-            'north_biters_boss',
-            'south_biters_boss',
-        },
-    }
-
-    for _, e in pairs(surface.find_entities_filtered(filter)) do
-        if e.name ~= 'atomic-rocket' then
-            e.active = false
-        end
+---Disable biters that are attacking entities during a ceasefire at the end of the game
+---Needs to be disabled on game start
+local enforce_biter_cease_fire_handler = Token.register(
+---@param event EventData.on_entity_damaged 
+    function (event)
+    local cause = event.cause
+    if cause and cause.valid and cause.type == 'unit' then
+        cause.active = false
     end
+end
+)
+---Disable all biters on game end by setting one-way cease fire from biter forces to their respective team.
+---More performant than scanning for all units and disabling them (which scales badly with explored map and number of biters on map)
+local function freeze_all_biters()
+    local teams = { game.forces.north, game.forces.south }
+    local biter_force 
+    for _, team in pairs(teams) do
+        biter_force = game.forces[team.name .. '_biters']
+        biter_force.set_cease_fire(team,true)
+        biter_force = game.forces[team.name .. '_biters_boss']
+        biter_force.set_cease_fire(team,true)
+    end
+    Event.add_removable(defines.events.on_entity_damaged, enforce_biter_cease_fire_handler)
 end
 
 local function biter_damage_source(event)
@@ -582,7 +590,7 @@ function Public.on_entity_died(entity)
     storage.results_sent_south = false
     storage.results_sent_north = false
 
-    freeze_all_biters(entity.surface)
+    freeze_all_biters()
     local special = storage.special_games_variables.captain_mode
     if special and not special.prepaPhase then
         storage.tournament_mode = false
@@ -968,6 +976,7 @@ function Public.generate_new_map()
     game.reset_time_played()
     storage.server_restart_timer = nil
     game.delete_surface(prev_surface)
+    Event.remove_removable(defines.events.on_entity_damaged, enforce_biter_cease_fire_handler)
     start_map_reroll()
 end
 

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -410,17 +410,22 @@ local enforce_biter_cease_fire_handler = Token.register(
     end
 end
 )
----Disable all biters on game end by setting one-way cease fire from biter forces to their respective team.
----More performant than scanning for all units and disabling them (which scales badly with explored map and number of biters on map)
-local function freeze_all_biters()
+---
+---@param cease_fire boolean
+local function toggle_biter_cease_fire(cease_fire)
     local teams = { game.forces.north, game.forces.south }
     local biter_force 
     for _, team in pairs(teams) do
         biter_force = game.forces[team.name .. '_biters']
-        biter_force.set_cease_fire(team,true)
+        biter_force.set_cease_fire(team,cease_fire)
         biter_force = game.forces[team.name .. '_biters_boss']
-        biter_force.set_cease_fire(team,true)
-    end
+        biter_force.set_cease_fire(team,cease_fire)
+    end 
+end
+---Disable all biters on game end by setting one-way cease fire from biter forces to their respective team.
+---More performant than scanning for all units and disabling them (which scales badly with explored map and number of biters on map)
+local function freeze_all_biters()
+    toggle_biter_cease_fire(true)
     Event.add_removable(defines.events.on_entity_damaged, enforce_biter_cease_fire_handler)
 end
 
@@ -977,6 +982,7 @@ function Public.generate_new_map()
     storage.server_restart_timer = nil
     game.delete_surface(prev_surface)
     Event.remove_removable(defines.events.on_entity_damaged, enforce_biter_cease_fire_handler)
+    toggle_biter_cease_fire(false)
     start_map_reroll()
 end
 


### PR DESCRIPTION
### Brief description of the changes:

Reduce time spent in a function called on game_end from ~120ms to ~1-2ms

(First PR, would love feedback and areas to improve. I have looked at contributing.md, other commits, and similar places in pre-existing code)

On game end/final silo destruction, there is a noticeable lag spike. This is more noticeable on maps with more map explored, and more entities.

I found I could avoid a call to surface.find_entities_filtered that disables all biters, by instead setting a one-way cease fire from the biter force to the respective team force.

In my basic testing, this reduces time in the method from ~120ms on my machine, down to ~1-2ms. I still notice a hitch, and am unsure where else to optimize as I am new to factorio modding and profiling, but the hitch that is there obviously takes significantly less time.

As biters that are currently attacking something will keep attacking their target when a cease fire is set, there is an additional on_entity_damaged that activates only on game end to disable them as they attack to stop new alerts, which is then removed on game restart.

Tested on a captain game save from 19 Feb for my profiled numbers

This is less noticeable on smaller shorter games due to less chunks and entities.

Avoiding a surface scan entirely is preferable, and this also keeps biter disable behavior consistent in newly generated chunks on game end. (currently entities in new chunks after game end are not disabled and still attack the player)

I don't expect biters wandering aimlessly around a little bit to be an issue for people. One way cease fire means teams can still attack them if they want to, and turrets still fire upon them, clearing incoming waves.

### Tested Changes:
- [x] I've tested the basic cease fire functionality locally 
- [x] I've profiled on a large save 
- [ ] Not tested disabling entities from on_entity_damaged event or its cleanup after restart
- [ ] Not tested in multiplayer

