### PR TITLE
Fix free command after prisoner changes remote view surface

### DIFF
--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -227,7 +227,7 @@ local on_player_changed_surface = function(event)
     end
 
     local surface = game.surfaces['gulag']
-    if player.surface.index ~= surface.index then
+    if player.physical_surface.index ~= surface.index then
         local p_data = get_player_data(player)
         if jailed[player.name] and p_data and p_data.locked then
             teleport_player_to_gulag(player, 'jail')
@@ -363,11 +363,6 @@ local jail = function(player, griefer, msg)
     -- Only perform teleport and character operations if player is online
     if connected then
         teleport_player_to_gulag(g, 'jail')
-
-        if g.surface.name == 'gulag' then
-            local gulag = get_gulag_permission_group()
-            gulag.add_player(griefer)
-        end
 
         if g.character and g.character.valid and g.character.driving then
             g.character.driving = false


### PR DESCRIPTION
steps to reproduce: 
1. /jail Player1
2. as Player1: /follow Player2
3. /free Player1
Player1 stuck in gulag because when follow it triggered `on_player_changed_surface` event

Additionally, this commit removes the redundant call to `gulag.add_player(griefer)` since it is already done in `teleport_player_to_gulag`.
 

### Tested Changes:
- [x] I've tested the changes locally or with people.

